### PR TITLE
Fixed deprecated Digest::Digest

### DIFF
--- a/lib/domain_tools/request.rb
+++ b/lib/domain_tools/request.rb
@@ -48,7 +48,7 @@ module DomainTools
       timestamp = Time.now.utc.strftime("%Y-%m-%dT%H:%M:%SZ")
       data      = @username+timestamp+uri
       require 'openssl'
-      digester  = OpenSSL::Digest::Digest.new(DomainTools::DIGEST)
+      digester  = OpenSSL::Digest.new(DomainTools::DIGEST)
       signature = OpenSSL::HMAC.hexdigest(digester, @key, data)
       ["api_username=#{@username}","signature=#{signature}","timestamp=#{timestamp}"].join("&")
     end


### PR DESCRIPTION
Hi, this fix the warning message of Digest::Digest deprecation.
https://github.com/ruby/ruby/pull/446/commits/78fadf071262ede83e722ba57d4e9b920bf44b82
